### PR TITLE
Tweaks to scripts to make RDS address dynamic.

### DIFF
--- a/dbInit/1_run_liquibase.sh
+++ b/dbInit/1_run_liquibase.sh
@@ -10,7 +10,7 @@ ${LIQUIBASE_HOME}/liquibase \
 --changeLogFile=${LIQUIBASE_HOME}/mlr-liquibase/postgres/changeLog.yml \
 --logLevel=debug \
 update \
--DMLR_LEGACY_PASSWORD=${MLR_LEGACY_PASSWORD} > ${LIQUIBASE_HOME}/liquibaseSuperuser.log
+-DMLR_LEGACY_PASSWORD=${MLR_LEGACY_PASSWORD} -DMLR_RDS_ADDRESS=${MLR_RDS_ADDRESS} > ${LIQUIBASE_HOME}/liquibaseSuperuser.log
 
 # application database create scripts
 ${LIQUIBASE_HOME}/liquibase \
@@ -18,7 +18,8 @@ ${LIQUIBASE_HOME}/liquibase \
 --classpath=${LIQUIBASE_HOME}/lib/postgresql-${POSTGRES_JDBC_VERSION}.jar \
 --changeLogFile=${LIQUIBASE_HOME}/mlr-liquibase/database/changeLog.yml \
 --logLevel=debug \
-update > ${LIQUIBASE_HOME}/liquibaseDatabaseCreate.log
+update \
+-DMLR_LEGACY_PASSWORD=${MLR_LEGACY_PASSWORD} -DMLR_RDS_ADDRESS=${MLR_RDS_ADDRESS} > ${LIQUIBASE_HOME}/liquibaseDatabaseCreate.log
 
 # application scripts
 ${LIQUIBASE_HOME}/liquibase \
@@ -27,4 +28,4 @@ ${LIQUIBASE_HOME}/liquibase \
 --changeLogFile=${LIQUIBASE_HOME}/mlr-liquibase/changeLog.yml \
 --logLevel=debug \
 update \
--DMLR_LEGACY_DATA_PASSWORD=${MLR_LEGACY_DATA_PASSWORD} -DMLR_LEGACY_USER_PASSWORD=${MLR_LEGACY_USER_PASSWORD} > ${LIQUIBASE_HOME}/liquibase.log
+-DMLR_LEGACY_DATA_PASSWORD=${MLR_LEGACY_DATA_PASSWORD} -DMLR_LEGACY_USER_PASSWORD=${MLR_LEGACY_USER_PASSWORD} -DMLR_RDS_ADDRESS=${MLR_RDS_ADDRESS} > ${LIQUIBASE_HOME}/liquibase.log

--- a/dbInit/databaseCreate.properties
+++ b/dbInit/databaseCreate.properties
@@ -1,4 +1,4 @@
 driver: org.postgresql.Driver
-url: jdbc:postgresql://127.0.0.1:5432/postgres
+url: jdbc:postgresql://${MLR_RDS_ADDRESS}/postgres
 username: mlr_legacy
 password: ${MLR_LEGACY_PASSWORD}

--- a/dbInit/liquibase.properties
+++ b/dbInit/liquibase.properties
@@ -1,4 +1,4 @@
 driver: org.postgresql.Driver
-url: jdbc:postgresql://127.0.0.1:5432/mlr_legacy
+url: jdbc:postgresql://${MLR_RDS_ADDRESS}/mlr_legacy
 username: mlr_legacy
 password: ${MLR_LEGACY_PASSWORD}

--- a/dbInit/postgres.properties
+++ b/dbInit/postgres.properties
@@ -1,4 +1,4 @@
 driver: org.postgresql.Driver
-url: jdbc:postgresql://127.0.0.1:5432/postgres
+url: jdbc:postgresql://${MLR_RDS_ADDRESS}/postgres
 username: postgres
 password: ${POSTGRES_PASSWORD}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,7 @@ services:
       - MLR_LEGACY_PASSWORD=${MLR_LEGACY_PASSWORD}
       - MLR_LEGACY_DATA_PASSWORD=${MLR_LEGACY_DATA_PASSWORD}
       - MLR_LEGACY_USER_PASSWORD=${MLR_LEGACY_USER_PASSWORD}
+      - MLR_RDS_ADDRESS=${MLR_RDS_ADDRESS}
     ports:
       - "5435:5432"
     container_name: mlr_legacy_db


### PR DESCRIPTION
Would this be able to be used similarly to your job https://rundeck.wma.usgs.chs.ead/project/PROD_OWI/job/show/c26312f1-dc2e-4b8d-b90e-dec396aacdaa for running liquibase against the MLR RDSs?  This creates the postgres db for running locally, but can we just run the liquibase part against an external-to-container RDS?