### PR TITLE
MLR-377: update dbInit script so that local liquibase runs successful…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -61,12 +61,6 @@ COPY ./dbInit/1_run_liquibase.sh /docker-entrypoint-initdb.d/
 
 COPY ./dbInit/z.sh /docker-entrypoint-initdb.d/
 
-COPY ./dbInit/postgres.properties $LIQUIBASE_HOME/
-
-COPY ./dbInit/databaseCreate.properties $LIQUIBASE_HOME/
-
-COPY ./dbInit/liquibase.properties $LIQUIBASE_HOME/
-
 RUN chmod -R 777 $LIQUIBASE_HOME
 
 HEALTHCHECK --interval=2s --timeout=3s \

--- a/dbInit/1_run_liquibase.sh
+++ b/dbInit/1_run_liquibase.sh
@@ -12,6 +12,8 @@ ${LIQUIBASE_HOME}/liquibase \
 --classpath=${LIQUIBASE_HOME}/lib/postgresql.jar \
 --changeLogFile=${LIQUIBASE_HOME}/mlr-legacy-liquibase/mlr-liquibase/postgres/postgres/changeLog.yml \
 --url=jdbc:postgresql://127.0.0.1:$PGPORT/postgres \
+--username=postgres \
+--password=${POSTGRES_PASSWORD} \
 --logLevel=debug \
 update \
 	-DPOSTGRES_PASSWORD=${POSTGRES_PASSWORD} \
@@ -23,6 +25,8 @@ ${LIQUIBASE_HOME}/liquibase \
 --defaultsFile=${LIQUIBASE_HOME}/mlr-legacy-liquibase/mlr-liquibase/databaseCreate.properties \
 --classpath=${LIQUIBASE_HOME}/lib/postgresql.jar \
 --changeLogFile=${LIQUIBASE_HOME}/mlr-legacy-liquibase/mlr-liquibase/postgres/mlr_legacy/changeLog.yml \
+--username=postgres \
+--password=${POSTGRES_PASSWORD} \
 --url=jdbc:postgresql://127.0.0.1:$PGPORT/mlr_legacy \
 --logLevel=debug \
 update \
@@ -34,6 +38,8 @@ ${LIQUIBASE_HOME}/liquibase \
 --classpath=${LIQUIBASE_HOME}/lib/postgresql.jar \
 --changeLogFile=${LIQUIBASE_HOME}/mlr-legacy-liquibase/mlr-liquibase/mlr_legacy/changeLog.yml \
 --url=jdbc:postgresql://127.0.0.1:$PGPORT/mlr_legacy \
+--username=mlr_legacy \
+--password=${MLR_LEGACY_PASSWORD} \
 --logLevel=debug \
 update \
 	-DMLR_LEGACY_PASSWORD=${MLR_LEGACY_PASSWORD} \
@@ -45,6 +51,8 @@ ${LIQUIBASE_HOME}/liquibase \
 --classpath=${LIQUIBASE_HOME}/lib/postgresql.jar \
 --changeLogFile=${LIQUIBASE_HOME}/mlr-legacy-liquibase/mlr-liquibase/mlr_legacy/testData/changeLogAK.yml \
 --url=jdbc:postgresql://127.0.0.1:$PGPORT/mlr_legacy \
+--username=mlr_legacy \
+--password=${MLR_LEGACY_PASSWORD} \
 --logLevel=debug \
 update \
 	-DMLR_LEGACY_PASSWORD=${MLR_LEGACY_PASSWORD}

--- a/dbInit/1_run_liquibase.sh
+++ b/dbInit/1_run_liquibase.sh
@@ -8,7 +8,6 @@ PGPORT=${PGPORT:-5432}
 
 # superuser scripts
 ${LIQUIBASE_HOME}/liquibase \
---defaultsFile=${LIQUIBASE_HOME}/mlr-legacy-liquibase/mlr-liquibase/postgres.properties \
 --classpath=${LIQUIBASE_HOME}/lib/postgresql.jar \
 --changeLogFile=${LIQUIBASE_HOME}/mlr-legacy-liquibase/mlr-liquibase/postgres/postgres/changeLog.yml \
 --url=jdbc:postgresql://127.0.0.1:$PGPORT/postgres \
@@ -22,7 +21,6 @@ update \
 
 # application database create scripts
 ${LIQUIBASE_HOME}/liquibase \
---defaultsFile=${LIQUIBASE_HOME}/mlr-legacy-liquibase/mlr-liquibase/databaseCreate.properties \
 --classpath=${LIQUIBASE_HOME}/lib/postgresql.jar \
 --changeLogFile=${LIQUIBASE_HOME}/mlr-legacy-liquibase/mlr-liquibase/postgres/mlr_legacy/changeLog.yml \
 --username=postgres \
@@ -34,7 +32,6 @@ update \
 
 # application scripts
 ${LIQUIBASE_HOME}/liquibase \
---defaultsFile=${LIQUIBASE_HOME}/mlr-legacy-liquibase/mlr-liquibase/liquibase.properties \
 --classpath=${LIQUIBASE_HOME}/lib/postgresql.jar \
 --changeLogFile=${LIQUIBASE_HOME}/mlr-legacy-liquibase/mlr-liquibase/mlr_legacy/changeLog.yml \
 --url=jdbc:postgresql://127.0.0.1:$PGPORT/mlr_legacy \
@@ -47,7 +44,6 @@ update \
 
 echo "data load scripts"
 ${LIQUIBASE_HOME}/liquibase \
---defaultsFile=${LIQUIBASE_HOME}/mlr-legacy-liquibase/mlr-liquibase/liquibase.properties \
 --classpath=${LIQUIBASE_HOME}/lib/postgresql.jar \
 --changeLogFile=${LIQUIBASE_HOME}/mlr-legacy-liquibase/mlr-liquibase/mlr_legacy/testData/changeLogAK.yml \
 --url=jdbc:postgresql://127.0.0.1:$PGPORT/mlr_legacy \

--- a/dbInit/databaseCreate.properties
+++ b/dbInit/databaseCreate.properties
@@ -1,3 +1,0 @@
-driver: org.postgresql.Driver
-username: mlr_legacy
-password: ${MLR_LEGACY_PASSWORD}

--- a/dbInit/liquibase.properties
+++ b/dbInit/liquibase.properties
@@ -1,3 +1,0 @@
-driver: org.postgresql.Driver
-username: mlr_legacy
-password: ${MLR_LEGACY_PASSWORD}

--- a/dbInit/postgres.properties
+++ b/dbInit/postgres.properties
@@ -1,3 +1,0 @@
-driver: org.postgresql.Driver
-username: postgres
-password: ${POSTGRES_PASSWORD}


### PR DESCRIPTION
…ly against MLR_Legacy_DB and ownership of objects is correct

It doesn't seem to matter what dbInit/databaseCreate.properties is - I tried it both with username/password postgres as well as mlr_legacy, and in both instances it worked. So I left that alone.